### PR TITLE
Improve heroku server startup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,7 @@ Hopefully the simulation is interesting to watch. You can see the current (unint
 
 ## Installation
 
-If you're an absolute beginner or want more detailed instructions, I have written a more [beginner-friendly guide](https://github.com/vegeta897/d-zone/wiki/Beginner's-Setup-Guide)
-
-```
-git clone https://github.com/vegeta897/d-zone.git
-cd d-zone
-npm install --no-optional
-```
-
-Set your `token` environment variable to your bot's token. Alternatively, create a file called `.env` in the project root and put `token="your_token"` in it. If you are hosting on HTTPS (recommended), you need to also set your `cert` and `key` variables to the full paths of your certificates (*e.g.* `/etc/letsencrypt/live/example.com/fullchain.pem` and `/etc/letsencrypt/live/example.com/privkey.pem`). These can also be set in the `.env` file.
-
-Rename `discord-config-example.json` to `discord-config.json` and insert the info for your Discord server(s). **You must specify _one_ `default` Discord server.** You can include multiple servers here, and as long as your bot can connect to them, they will be available for clients to view.
-
-You can password-protect a server from being viewed by a client by using the `password` property. Check the [Configuration](https://github.com/vegeta897/d-zone/wiki/Configuration) reference for more info.
-
-You can automatically populate your `discord-config.json` with all your bot's servers by running `Update Configuration.bat`.
-
-Rename `socket-config-example.json` to `socket-config.json` and insert the address and port you want to run the websocket on. If you are using HTTPS, set `secure` to `true`. **Make sure the address matches your certificate name if using HTTPS.** An IP address won't work with your certificate.
-
-Start the server with `npm start` or just `node index.js`. You may need to run this as admin to access the cert files, if you're using them.
-
-The client files are all contained within the `web` folder, and need to be built into `/static/bundle.js`  with `npm run-script build` or `npm run-script watch`. Upload everything in the `web` folder except the `script` folder. _Do not_ remove the web folder from the package; the server component requires it.
-
-Remember, if you're running the server without HTTPS, then the web files must be accessible via HTTP.
-
-If everything works, the client should connect to the default server, generate a world, and receive live updates via websocket from the server.
-
-You can tweak the message box parameters by editing `misc-config.json`. Check the [Misc Config](https://github.com/vegeta897/d-zone/wiki/Configuration#misc) reference for details.
-
-Remember, this project is still being developed, so check back here for updates!
-
-Don't forget to rebuild `bundle.js` and re-upload the web files after updating!
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/d-zone-org/d-zone/tree/heroku)
 
 ## Design
 The game engine architecture is currently loosely based on [crtrdg](http://crtrdg.com/).

--- a/index.js
+++ b/index.js
@@ -4,44 +4,40 @@ require('dotenv').config({ path: path.join(__dirname, '.env') });
 var discordConfig = require('./discord-config');
 var socketConfig = require('./socket-config');
 var Inbox = require('./script/inbox.js');
+var WebSock = require('./script/websock.js');
 
 console.log('Initializing server');
 
-var WebSock = require('./script/websock.js');
+var webSock = new WebSock(socketConfig,
+    function onConnect(socket) {
+        socket.send(JSON.stringify({ type: 'server-list', data: inbox.getServers() }));
+    },
+    function onJoinServer(socket, connectRequest) {
+        var users = inbox.getUsers(connectRequest);
+        if(users === 'unknown-server') {
+            socket.send(JSON.stringify({
+                type: 'error', data: { message: 'Sorry, couldn\'t connect to that Discord server.' }
+            }));
+        } else if(users === 'bad-password') {
+            socket.send(JSON.stringify({
+                type: 'error', data: { message: 'Sorry, wrong password for that Discord server.' }
+            }));
+            console.log('Client used wrong password to join server', connectRequest.server, connectRequest.password);
+        } else {
+            socket.discordServer = users.server.discordID;
+            // Send list of current online users to set up initial client state
+            console.log('Client joined server', users.server.name);
+            socket.send(JSON.stringify({
+                type: 'server-join', data: {
+                    users: users.userList, request: connectRequest
+                }
+            }));
+        }
+    }
+);
 
 var inbox = new Inbox(discordConfig);
-
-var webSock;
-
 inbox.on('connected', () => {
-    console.log('Inbox connected');
-    webSock = new WebSock(socketConfig,
-        function onConnect(socket) {
-            socket.send(JSON.stringify({ type: 'server-list', data: inbox.getServers() }));
-        },
-        function onJoinServer(socket, connectRequest) {
-            var users = inbox.getUsers(connectRequest);
-            if(users === 'unknown-server') {
-                socket.send(JSON.stringify({
-                    type: 'error', data: { message: 'Sorry, couldn\'t connect to that Discord server.' }
-                }));
-            } else if(users === 'bad-password') {
-                socket.send(JSON.stringify({
-                    type: 'error', data: { message: 'Sorry, wrong password for that Discord server.' }
-                }));
-                console.log('Client used wrong password to join server', connectRequest.server, connectRequest.password);
-            } else {
-                socket.discordServer = users.server.discordID;
-                // Send list of current online users to set up initial client state
-                console.log('Client joined server', users.server.name);
-                socket.send(JSON.stringify({
-                    type: 'server-join', data: {
-                        users: users.userList, request: connectRequest
-                    }
-                }));
-            }
-        }
-    );
     inbox.on('message', webSock.sendData.bind(webSock));
     inbox.on('presence', webSock.sendData.bind(webSock));
 });

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ console.log('Initializing server');
 
 var webSock = new WebSock(socketConfig,
     function onConnect(socket) {
-        socket.send(JSON.stringify({ type: 'server-list', data: inbox.getServers() }));
+        var data = inbox.getServers();
+        if(!data) socket.send(JSON.stringify({ type: 'error', data: { message: 'The server is not ready yet, try again shortly.' } }));
+        else socket.send(JSON.stringify({ type: 'server-list', data }));
     },
     function onJoinServer(socket, connectRequest) {
         var users = inbox.getUsers(connectRequest);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var inbox = new Inbox(discordConfig);
 var webSock;
 
 inbox.on('connected', () => {
+    console.log('Inbox connected');
     webSock = new WebSock(socketConfig,
         function onConnect(socket) {
             socket.send(JSON.stringify({ type: 'server-list', data: inbox.getServers() }));

--- a/script/inbox.js
+++ b/script/inbox.js
@@ -10,6 +10,7 @@ inherits(Inbox, EventEmitter);
 var commandCooldowns = {};
 
 function Inbox(config) {
+    console.log('Inbox instantiating...');
     EventEmitter.call(this);
     var bot = new Eris(process.env.TOKEN, { getAllUsers: true });
     this.bot = bot;
@@ -33,6 +34,7 @@ function Inbox(config) {
         channel.createMessage(info);
     }
     bot.on('ready', () => {
+        console.log('Discord bot connected');
         if(self.servers) return; // Don't re-initialize if reconnecting
         console.log(new Date(), 'Logged in as: ' + bot.user.username + ' - (' + bot.user.id + ')');
         var serverList = config.get('servers');

--- a/script/inbox.js
+++ b/script/inbox.js
@@ -152,6 +152,7 @@ Inbox.prototype.getUsers = function(connectRequest) {
 };
 
 Inbox.prototype.getServers = function() {
+    if(!this.servers) return;
     let serverList = {};
     for(let [sKey, server] of this.servers.entries()) {
         serverList[sKey] = { id: server.id, name: server.name };

--- a/script/inbox.js
+++ b/script/inbox.js
@@ -10,7 +10,6 @@ inherits(Inbox, EventEmitter);
 var commandCooldowns = {};
 
 function Inbox(config) {
-    console.log('Inbox instantiating...');
     EventEmitter.call(this);
     var bot = new Eris(process.env.TOKEN, { getAllUsers: true });
     this.bot = bot;
@@ -34,7 +33,6 @@ function Inbox(config) {
         channel.createMessage(info);
     }
     bot.on('ready', () => {
-        console.log('Discord bot connected');
         if(self.servers) return; // Don't re-initialize if reconnecting
         console.log(new Date(), 'Logged in as: ' + bot.user.username + ' - (' + bot.user.id + ')');
         var serverList = config.get('servers');


### PR DESCRIPTION
Recent Discord API changes may be causing a considerably longer bot connection time when using `getAllUsers`. Heroku kills your application if it fails to bind to the application port within 60 seconds.

This PR changes the startup routine so that the express and websocket servers can bind to the port immediately instead of waiting for Discord.

An error message is shown on the web client if trying to connect before Discord is ready.