### PR TITLE
Improve map system 🗺

### DIFF
--- a/src/modules/game/common/cell-3d.ts
+++ b/src/modules/game/common/cell-3d.ts
@@ -23,31 +23,31 @@ export class Cell3D {
 		this.attributes = { ...DEFAULT_ATTRIBUTES, ...attributes }
 	}
 
-	setGrid(grid: IGrid): void {
-		this.x = grid.x
-		this.y = grid.y
-		this.z = grid.z
+	setGrid({ x, y, z }: IGrid): void {
+		this.x = x
+		this.y = y
+		this.z = z
 	}
 
 	moveTo(grid: IGrid): Cell3D[] {
 		return this.map.moveCellToGrid(this, grid)
 	}
 
-	getCellsAtNeighbor(grid: IGrid): Cell3D[] {
+	getCellsAtNeighbor({ x, y, z }: IGrid): Cell3D[] {
 		return this.map.getCellsAtGrid({
-			x: this.x + grid.x,
-			y: this.y + grid.y,
-			z: this.z + grid.z,
+			x: this.x + x,
+			y: this.y + y,
+			z: this.z + z,
 		})
 	}
 
-	spread(grid: IGrid, attributes?: ICell3DAttributes): Cell3D[] {
+	spread({ x, y, z }: IGrid, attributes?: ICell3DAttributes): Cell3D[] {
 		return this.map.addCell(
 			new Cell3D({
 				map: this.map,
-				x: this.x + grid.x,
-				y: this.y + grid.y,
-				z: this.z + grid.z,
+				x: this.x + x,
+				y: this.y + y,
+				z: this.z + z,
 				parentCell: this,
 				attributes,
 			})

--- a/src/modules/game/common/cell-3d.ts
+++ b/src/modules/game/common/cell-3d.ts
@@ -1,24 +1,32 @@
 import Map3D from './map-3d'
 import { IGrid } from '../typings'
 
+const ATTRIBUTE_DEFAULTS: ICell3DAttributes = {
+	solid: false,
+	platform: false,
+}
+
 export class Cell3D {
 	readonly map: Map3D
 	x: number
 	y: number
 	z: number
 	parentCell?: Cell3D
-	properties: ICell3DProperties = {}
-	constructor(options: ICell3DOptions) {
-		this.map = options.map
-		this.x = options.x
-		this.y = options.y
-		this.z = options.z
-		if (options.parentCell) this.parentCell = options.parentCell
-		Object.assign(this.properties, options.properties)
+	attributes: ICell3DAttributes
+
+	constructor({ map, parentCell, attributes, x, y, z }: ICell3DOptions) {
+		this.map = map
+		this.x = x
+		this.y = y
+		this.z = z
+		this.parentCell = parentCell
+		this.attributes = { ...ATTRIBUTE_DEFAULTS, ...attributes }
 	}
+
 	moveTo(grid: IGrid): Cell3D[] {
 		return this.map.moveCellToGrid(this, grid)
 	}
+
 	getCellsAtNeighbor(grid: IGrid): Cell3D[] {
 		return this.map.getCellsAtGrid({
 			x: this.x + grid.x,
@@ -26,7 +34,8 @@ export class Cell3D {
 			z: this.z + grid.z,
 		})
 	}
-	spread(grid: IGrid, cellProperties?: ICell3DProperties): Cell3D[] {
+
+	spread(grid: IGrid, attributes?: ICell3DAttributes): Cell3D[] {
 		return this.map.addCell(
 			new Cell3D({
 				map: this.map,
@@ -34,10 +43,11 @@ export class Cell3D {
 				y: this.y + grid.y,
 				z: this.z + grid.z,
 				parentCell: this,
-				properties: cellProperties,
+				attributes: attributes,
 			})
 		)
 	}
+
 	destroy(): Cell3D[] {
 		return this.map.removeCellFromGrid(this, this)
 	}
@@ -46,10 +56,10 @@ export class Cell3D {
 export interface ICell3DOptions extends IGrid {
 	map: Map3D
 	parentCell?: Cell3D
-	properties?: ICell3DProperties
+	attributes?: ICell3DAttributes
 }
 
-interface ICell3DProperties {
+interface ICell3DAttributes {
 	solid?: boolean
 	platform?: boolean
 }

--- a/src/modules/game/common/cell-3d.ts
+++ b/src/modules/game/common/cell-3d.ts
@@ -23,6 +23,12 @@ export class Cell3D {
 		this.attributes = { ...DEFAULT_ATTRIBUTES, ...attributes }
 	}
 
+	setGrid(grid: IGrid): void {
+		this.x = grid.x
+		this.y = grid.y
+		this.z = grid.z
+	}
+
 	moveTo(grid: IGrid): Cell3D[] {
 		return this.map.moveCellToGrid(this, grid)
 	}
@@ -43,7 +49,7 @@ export class Cell3D {
 				y: this.y + grid.y,
 				z: this.z + grid.z,
 				parentCell: this,
-				attributes: attributes,
+				attributes,
 			})
 		)
 	}

--- a/src/modules/game/common/cell-3d.ts
+++ b/src/modules/game/common/cell-3d.ts
@@ -1,7 +1,7 @@
 import Map3D from './map-3d'
 import { IGrid } from '../typings'
 
-const ATTRIBUTE_DEFAULTS: ICell3DAttributes = {
+const DEFAULT_ATTRIBUTES: ICell3DAttributes = {
 	solid: false,
 	platform: false,
 }
@@ -20,7 +20,7 @@ export class Cell3D {
 		this.y = y
 		this.z = z
 		this.parentCell = parentCell
-		this.attributes = { ...ATTRIBUTE_DEFAULTS, ...attributes }
+		this.attributes = { ...DEFAULT_ATTRIBUTES, ...attributes }
 	}
 
 	moveTo(grid: IGrid): Cell3D[] {

--- a/src/modules/game/common/map-3d.ts
+++ b/src/modules/game/common/map-3d.ts
@@ -28,7 +28,7 @@ export default class Map3D {
 
 	moveCellToGrid(cell: Cell3D, grid: IGrid): Cell3D[] {
 		this.removeCellFromGrid(cell, cell)
-		Object.assign(cell, grid)
+		cell.setGrid(grid)
 		return this.addCell(cell)
 	}
 

--- a/src/modules/game/common/map-3d.ts
+++ b/src/modules/game/common/map-3d.ts
@@ -2,10 +2,8 @@ import { Cell3D } from './cell-3d'
 import { Direction, IGrid, IGridDirection } from '../typings'
 
 export default class Map3D {
-	private data: Map<string, Cell3D[]>
-	constructor() {
-		this.data = new Map()
-	}
+	private data: Map<string, Cell3D[]> = new Map()
+
 	getCellsAtGrid(grid: IGrid): Cell3D[] {
 		const hash = Map3D.gridToHash(grid)
 		let cells = this.data.get(hash)

--- a/src/modules/game/common/map-3d.ts
+++ b/src/modules/game/common/map-3d.ts
@@ -32,8 +32,8 @@ export default class Map3D {
 		return this.addCell(cell)
 	}
 
-	static gridToHash(grid: IGrid): string {
-		return grid.x + ':' + grid.y + ':' + grid.z
+	static gridToHash({ x, y, z }: IGrid): string {
+		return x + ':' + y + ':' + z
 	}
 
 	static Directions: Record<Direction, IGridDirection> = {

--- a/src/modules/game/common/map-3d.ts
+++ b/src/modules/game/common/map-3d.ts
@@ -11,27 +11,31 @@ export default class Map3D {
 			cells = []
 			this.data.set(hash, cells)
 		}
-		return cells
+		return [...cells]
 	}
+
 	addCell(cell: Cell3D): Cell3D[] {
-		const cells = this.getCellsAtGrid(cell)
-		cells.push(cell)
-		return cells
+		const cells = [...this.getCellsAtGrid(cell), cell]
+		this.data.set(Map3D.gridToHash(cell), cells)
+		return [...cells]
 	}
+
 	removeCellFromGrid(cell: Cell3D, grid: IGrid): Cell3D[] {
-		const cells = this.getCellsAtGrid(grid)
-		const cellIndex = cells.indexOf(cell)
-		if (cellIndex >= 0) cells.splice(cellIndex, 1)
-		return cells
+		const cells = this.getCellsAtGrid(grid).filter((c) => c !== cell)
+		this.data.set(Map3D.gridToHash(cell), cells)
+		return [...cells]
 	}
+
 	moveCellToGrid(cell: Cell3D, grid: IGrid): Cell3D[] {
 		this.removeCellFromGrid(cell, cell)
 		Object.assign(cell, grid)
 		return this.addCell(cell)
 	}
+
 	static gridToHash(grid: IGrid): string {
 		return grid.x + ':' + grid.y + ':' + grid.z
 	}
+
 	static Directions: Record<Direction, IGridDirection> = {
 		east: { x: 1, y: 0, z: 0, direction: Direction.East },
 		west: { x: -1, y: 0, z: 0, direction: Direction.West },

--- a/src/modules/game/constants.ts
+++ b/src/modules/game/constants.ts
@@ -1,8 +1,0 @@
-import { Direction, IGridDirection } from './typings'
-
-export const DIRECTIONS: Record<Direction, IGridDirection> = {
-	east: { x: 1, y: 0, z: 0, direction: Direction.East },
-	west: { x: -1, y: 0, z: 0, direction: Direction.West },
-	south: { y: 1, x: 0, z: 0, direction: Direction.South },
-	north: { y: -1, x: 0, z: 0, direction: Direction.North },
-} as const

--- a/src/modules/game/engine/archetypes/actor.ts
+++ b/src/modules/game/engine/archetypes/actor.ts
@@ -33,7 +33,7 @@ export function createActor(world: World, grid: IGrid, map: Map3D): Entity {
 				cell: new Cell3D({
 					map,
 					...grid,
-					properties: { solid: true, platform: true },
+					attributes: { solid: true, platform: true },
 				}),
 			},
 		},
@@ -55,7 +55,7 @@ export function reserveTarget(cell: Cell3D, target: IGrid): void {
 
 export function getValidHop(cell: Cell3D, hop: IGrid): IGrid | false {
 	const aboveNeighbor = cell.getCellsAtNeighbor({ x: 0, y: 0, z: 1 })
-	if (aboveNeighbor.some((cell) => cell.properties.solid)) return false
+	if (aboveNeighbor.some((cell) => cell.attributes.solid)) return false
 	const target = { x: cell.x + hop.x, y: cell.y + hop.y, z: cell.z }
 	for (const z of HOP_Z_LEVELS) {
 		target.z = cell.z + z
@@ -73,7 +73,7 @@ function gridIsEmpty(map: Map3D, grid: IGrid): boolean {
 	// If grid is below ground, it's not empty
 	if (grid.z < 0) return false
 	const cells = map.getCellsAtGrid(grid)
-	return !cells.some((cell) => cell.properties.solid)
+	return !cells.some((cell) => cell.attributes.solid)
 }
 
 function gridIsAbovePlatform(map: Map3D, grid: IGrid): boolean {
@@ -83,5 +83,5 @@ function gridIsAbovePlatform(map: Map3D, grid: IGrid): boolean {
 		...grid,
 		z: grid.z - 1,
 	})
-	return underNewTarget.some((cell) => cell.properties.platform)
+	return underNewTarget.some((cell) => cell.attributes.platform)
 }

--- a/src/modules/game/engine/archetypes/actor.ts
+++ b/src/modules/game/engine/archetypes/actor.ts
@@ -1,0 +1,35 @@
+import type { IGrid } from '../../typings'
+import { Cell3D } from '../../common/cell-3d'
+import Map3D from '../../common/map-3d'
+
+const HOP_Z_LEVELS = [0, 1, -1] as const
+
+export function reserveTarget(cell: Cell3D, target: IGrid): void {
+	cell.spread(target, { solid: true })
+}
+
+export function getHopTarget(cell: Cell3D, target: IGrid): IGrid | false {
+	const aboveNeighbor = cell.getCellsAtNeighbor({ x: 0, y: 0, z: 1 })
+	if (aboveNeighbor.some((cell) => cell.properties.solid)) return false
+	const newTarget = { ...target }
+	for (const z of HOP_Z_LEVELS) {
+		newTarget.z = z
+		const newTargetCells = cell.getCellsAtNeighbor(newTarget)
+		if (
+			gridIsAbovePlatform(cell.map, target) &&
+			!newTargetCells.some((cell) => cell.properties.solid)
+		) {
+			return newTarget
+		}
+	}
+	return false
+}
+
+function gridIsAbovePlatform(map: Map3D, grid: IGrid): boolean {
+	if (grid.z <= 0) return true
+	const underNewTarget = map.getCellsAtGrid({
+		...grid,
+		z: grid.z - 1,
+	})
+	return underNewTarget.some((cell) => cell.properties.platform)
+}

--- a/src/modules/game/engine/archetypes/actor.ts
+++ b/src/modules/game/engine/archetypes/actor.ts
@@ -53,24 +53,31 @@ export function reserveTarget(cell: Cell3D, target: IGrid): void {
 	cell.spread(target, { solid: true })
 }
 
-export function getHopTarget(cell: Cell3D, target: IGrid): IGrid | false {
+export function getValidHop(cell: Cell3D, hop: IGrid): IGrid | false {
 	const aboveNeighbor = cell.getCellsAtNeighbor({ x: 0, y: 0, z: 1 })
 	if (aboveNeighbor.some((cell) => cell.properties.solid)) return false
-	const newTarget = { ...target }
+	const target = { x: cell.x + hop.x, y: cell.y + hop.y, z: cell.z }
 	for (const z of HOP_Z_LEVELS) {
-		newTarget.z = z
-		const newTargetCells = cell.getCellsAtNeighbor(newTarget)
+		target.z = cell.z + z
 		if (
 			gridIsAbovePlatform(cell.map, target) &&
-			!newTargetCells.some((cell) => cell.properties.solid)
+			gridIsEmpty(cell.map, target)
 		) {
-			return newTarget
+			return { ...hop, z }
 		}
 	}
 	return false
 }
 
+function gridIsEmpty(map: Map3D, grid: IGrid): boolean {
+	// If grid is below ground, it's not empty
+	if (grid.z < 0) return false
+	const cells = map.getCellsAtGrid(grid)
+	return !cells.some((cell) => cell.properties.solid)
+}
+
 function gridIsAbovePlatform(map: Map3D, grid: IGrid): boolean {
+	// If grid is at ground level, it's on a platform
 	if (grid.z <= 0) return true
 	const underNewTarget = map.getCellsAtGrid({
 		...grid,

--- a/src/modules/game/engine/archetypes/actor.ts
+++ b/src/modules/game/engine/archetypes/actor.ts
@@ -1,8 +1,53 @@
-import type { IGrid } from '../../typings'
+import type { Entity, World } from 'ape-ecs'
+import type { IGrid, IGridDirection } from '../../typings'
+import type Map3D from '../../common/map-3d'
 import { Cell3D } from '../../common/cell-3d'
-import Map3D from '../../common/map-3d'
+import Transform from '../components/transform'
+import Sprite from '../components/sprite'
+import Actor from '../components/actor'
+import MapCell from '../components/map-cell'
+import Hop from '../components/hop'
+import { randomColor, randomHop, randomString } from '../seed-dev'
 
 const HOP_Z_LEVELS = [0, 1, -1] as const
+
+export function createActor(world: World, grid: IGrid, map: Map3D): Entity {
+	return world.createEntity({
+		c: {
+			[Transform.key]: {
+				type: Transform.typeName,
+				...grid,
+			},
+			[Sprite.key]: {
+				type: Sprite.typeName,
+				texture: 'cube:0',
+			},
+			[Actor.key]: {
+				type: Actor.typeName,
+				userID: randomString([48, 57], 18),
+				username: randomString([32, 126], Math.floor(Math.random() * 12) + 3),
+				color: randomColor(),
+			},
+			[MapCell.key]: {
+				type: MapCell.typeName,
+				cell: new Cell3D({
+					map,
+					...grid,
+					properties: { solid: true, platform: true },
+				}),
+			},
+		},
+	})
+}
+
+export function hopActor(actor: Entity, direction?: IGridDirection) {
+	if (actor.has(Hop.typeName)) return // Already hopping
+	actor.addComponent({
+		type: Hop.typeName,
+		key: Hop.key,
+		...(direction || randomHop()),
+	})
+}
 
 export function reserveTarget(cell: Cell3D, target: IGrid): void {
 	cell.spread(target, { solid: true })

--- a/src/modules/game/engine/seed-dev.ts
+++ b/src/modules/game/engine/seed-dev.ts
@@ -7,7 +7,6 @@ import Actor from './components/actor'
 import Hop from './components/hop'
 import MapCell from './components/map-cell'
 import Engine from '.'
-import { DIRECTIONS } from '../constants'
 import { Direction, IGrid, IGridDirection } from '../typings'
 
 export function createActor(world: World, grid: IGrid, map: Map3D): Entity {
@@ -106,33 +105,36 @@ export function hopActor(actor: Entity, direction?: IGridDirection) {
 }
 
 export function randomHop(): IGridDirection {
-	const direction = Object.keys(DIRECTIONS)[
+	const direction = Object.keys(Map3D.Directions)[
 		Math.floor(Math.random() * 4)
 	] as Direction
-	return DIRECTIONS[direction]
+	return Map3D.Directions[direction]
 }
 
 export function hopTest(world: World, map: Map3D) {
 	createActor(world, { x: 1, y: 0, z: 0 }, map)
 	const hop2 = createActor(world, { x: 1, y: 0, z: 1 }, map)
 	setTimeout(() => {
-		hopActor(hop2, DIRECTIONS.west)
+		hopActor(hop2, Map3D.Directions.west)
 	}, 1700)
 	createActor(world, { x: 0, y: 0, z: 0 }, map)
 	createActor(world, { x: 0, y: -1, z: 0 }, map)
 	createActor(world, { x: 0, y: -1, z: 1 }, map)
-	hopActor(createActor(world, { x: 0, y: -1, z: 2 }, map), DIRECTIONS.south)
+	hopActor(
+		createActor(world, { x: 0, y: -1, z: 2 }, map),
+		Map3D.Directions.south
+	)
 
 	createActor(world, { x: -1, y: 4, z: 0 }, map)
 	createActor(world, { x: 0, y: 4, z: 0 }, map)
 	createActor(world, { x: 0, y: 4, z: 1 }, map)
-	hopActor(createActor(world, { x: 0, y: 4, z: 2 }, map), DIRECTIONS.west)
+	hopActor(createActor(world, { x: 0, y: 4, z: 2 }, map), Map3D.Directions.west)
 
 	for (let i = 0; i < 4; i++) {
 		const hopper = createActor(world, { x: 4, y: i, z: 0 }, map)
 		setTimeout(() => {
 			setInterval(() => {
-				hopActor(hopper, DIRECTIONS.south)
+				hopActor(hopper, Map3D.Directions.south)
 			}, 1500)
 		}, i * 300)
 	}

--- a/src/modules/game/engine/seed-dev.ts
+++ b/src/modules/game/engine/seed-dev.ts
@@ -1,42 +1,7 @@
-import { Entity, IEntityConfig, World } from 'ape-ecs'
+import type { Entity, World } from 'ape-ecs'
+import type { Direction, IGrid, IGridDirection } from '../typings'
 import Map3D from '../common/map-3d'
-import { Cell3D } from '../common/cell-3d'
-import Transform from './components/transform'
-import Sprite from './components/sprite'
-import Actor from './components/actor'
-import Hop from './components/hop'
-import MapCell from './components/map-cell'
-import Engine from '.'
-import { Direction, IGrid, IGridDirection } from '../typings'
-
-export function createActor(world: World, grid: IGrid, map: Map3D): Entity {
-	return world.createEntity({
-		c: {
-			[Transform.key]: {
-				type: Transform.typeName,
-				...grid,
-			},
-			[Sprite.key]: {
-				type: Sprite.typeName,
-				texture: 'cube:0',
-			},
-			[Actor.key]: {
-				type: Actor.typeName,
-				userID: randomString([48, 57], 18),
-				username: randomString([32, 126], Math.floor(Math.random() * 12) + 3),
-				color: randomColor(),
-			},
-			[MapCell.key]: {
-				type: MapCell.typeName,
-				cell: new Cell3D({
-					map,
-					...grid,
-					properties: { solid: true, platform: true },
-				}),
-			},
-		},
-	} as IEntityConfig)
-}
+import { createActor, hopActor } from './archetypes/actor'
 
 export function addActors(world: World, map: Map3D, count: number): Entity[] {
 	const entities: Entity[] = []
@@ -62,7 +27,7 @@ export function randomString(
 	return value
 }
 
-const COLORS: number[] = [
+const ACTOR_COLORS: number[] = [
 	0x119922,
 	0x99ff22,
 	0x00ff22,
@@ -72,7 +37,7 @@ const COLORS: number[] = [
 ]
 
 export function randomColor(): number {
-	return COLORS[Math.floor(Math.random() * COLORS.length)]
+	return ACTOR_COLORS[Math.floor(Math.random() * ACTOR_COLORS.length)]
 }
 
 export function createGridPool(
@@ -93,15 +58,6 @@ export function createGridPool(
 		}
 	}
 	return pool
-}
-
-export function hopActor(actor: Entity, direction?: IGridDirection) {
-	if (actor.has(Hop.typeName)) return // Already hopping
-	actor.addComponent({
-		type: Hop.typeName,
-		key: Hop.key,
-		...(direction || randomHop()),
-	})
 }
 
 export function randomHop(): IGridDirection {
@@ -140,8 +96,8 @@ export function hopTest(world: World, map: Map3D) {
 	}
 }
 
-export function seedGame(engine: Engine, map: Map3D) {
-	const actors = addActors(engine.world, map, 100)
+export function seedGame(world: World, map: Map3D) {
+	const actors = addActors(world, map, 100)
 	setInterval(() => {
 		hopActor(actors[Math.floor(Math.random() * actors.length)])
 	}, 250)

--- a/src/modules/game/engine/seed-dev.ts
+++ b/src/modules/game/engine/seed-dev.ts
@@ -68,11 +68,11 @@ export function randomHop(): IGridDirection {
 }
 
 export function hopTest(world: World, map: Map3D) {
-	createActor(world, { x: 1, y: 0, z: 0 }, map)
-	const hop2 = createActor(world, { x: 1, y: 0, z: 1 }, map)
+	createActor(world, { x: 0, y: 0, z: 0 }, map)
+	const hop2 = createActor(world, { x: 0, y: 0, z: 1 }, map)
 	setTimeout(() => {
 		hopActor(hop2, Map3D.Directions.west)
-	}, 1700)
+	}, 1000)
 	createActor(world, { x: 0, y: 0, z: 0 }, map)
 	createActor(world, { x: 0, y: -1, z: 0 }, map)
 	createActor(world, { x: 0, y: -1, z: 1 }, map)
@@ -101,4 +101,5 @@ export function seedGame(world: World, map: Map3D) {
 	setInterval(() => {
 		hopActor(actors[Math.floor(Math.random() * actors.length)])
 	}, 250)
+	// hopTest(world, map)
 }

--- a/src/modules/game/engine/systems/hop.ts
+++ b/src/modules/game/engine/systems/hop.ts
@@ -28,7 +28,7 @@ export default class HopSystem extends System {
 			const actorCell = entity.c[MapCell.key].cell as Cell3D
 			const validHop = getValidHop(actorCell, hop)
 			if (validHop) {
-				Object.assign(hop, validHop)
+				hop.z = validHop.z
 				reserveTarget(actorCell, validHop)
 				actorCell.attributes.platform = false
 			} else {

--- a/src/modules/game/engine/systems/hop.ts
+++ b/src/modules/game/engine/systems/hop.ts
@@ -5,6 +5,8 @@ import Sprite from '../components/sprite'
 import MapCell from '../components/map-cell'
 import { HOP_OFFSETS, HOP_FRAMERATE } from '../../config/sprite'
 import { Animations, Direction } from '../../typings'
+import { Cell3D } from '../../common/cell-3d'
+import { reserveTarget, getHopTarget } from '../archetypes/actor'
 
 export default class HopSystem extends System {
 	private animations!: Animations
@@ -23,10 +25,10 @@ export default class HopSystem extends System {
 		let needRefresh = false
 		this.hopQuery.added.forEach((entity) => {
 			const hop = entity.c[Hop.key] as Hop
-			const actorCell = entity.c[MapCell.key].cell
-			const target = actorCell.getHopTarget(hop)
+			const actorCell = entity.c[MapCell.key].cell as Cell3D
+			const target = getHopTarget(actorCell, hop)
 			if (target) {
-				actorCell.reserveTarget(target)
+				reserveTarget(actorCell, target)
 				actorCell.properties.platform = false
 				Object.assign(hop, target)
 			} else {

--- a/src/modules/game/engine/systems/hop.ts
+++ b/src/modules/game/engine/systems/hop.ts
@@ -6,7 +6,7 @@ import MapCell from '../components/map-cell'
 import { HOP_OFFSETS, HOP_FRAMERATE } from '../../config/sprite'
 import { Animations, Direction } from '../../typings'
 import { Cell3D } from '../../common/cell-3d'
-import { reserveTarget, getHopTarget } from '../archetypes/actor'
+import { reserveTarget, getValidHop } from '../archetypes/actor'
 
 export default class HopSystem extends System {
 	private animations!: Animations
@@ -26,11 +26,11 @@ export default class HopSystem extends System {
 		this.hopQuery.added.forEach((entity) => {
 			const hop = entity.c[Hop.key] as Hop
 			const actorCell = entity.c[MapCell.key].cell as Cell3D
-			const target = getHopTarget(actorCell, hop)
-			if (target) {
-				reserveTarget(actorCell, target)
+			const validHop = getValidHop(actorCell, hop)
+			if (validHop) {
+				Object.assign(hop, validHop)
+				reserveTarget(actorCell, validHop)
 				actorCell.properties.platform = false
-				Object.assign(hop, target)
 			} else {
 				faceSpriteToHop(entity.c[Sprite.key] as Sprite, hop)
 				entity.removeComponent(hop)

--- a/src/modules/game/engine/systems/hop.ts
+++ b/src/modules/game/engine/systems/hop.ts
@@ -30,7 +30,7 @@ export default class HopSystem extends System {
 			if (validHop) {
 				Object.assign(hop, validHop)
 				reserveTarget(actorCell, validHop)
-				actorCell.properties.platform = false
+				actorCell.attributes.platform = false
 			} else {
 				faceSpriteToHop(entity.c[Sprite.key] as Sprite, hop)
 				entity.removeComponent(hop)
@@ -54,7 +54,7 @@ export default class HopSystem extends System {
 					z: z + hop.z,
 				})
 				faceSpriteToHop(sprite, hop)
-				entity.c[MapCell.key].cell.properties.platform = true
+				entity.c[MapCell.key].cell.attributes.platform = true
 				entity.removeComponent(hop)
 			} else if (hop.progress === 0 || frame > hop.frame) {
 				hop.frame = frame

--- a/src/modules/game/index.ts
+++ b/src/modules/game/index.ts
@@ -25,8 +25,8 @@ export default class Game {
 		registerECS(this.engine, this.renderer, this.resources)
 		console.log('ECS world initialized!', this.engine.world)
 
-		// Add placeholder content
-		seedGame(this.engine, this.map)
+		// Create placeholder activity
+		seedGame(this.engine.world, this.map)
 
 		// Start update loop
 		this.engine.start(FPS)


### PR DESCRIPTION
This addresses some shortcomings and things that bothered me about the map system and how it was used.

- Upgrade map system to support multiple cells at one location
- Get rid of `EmptyCell` and `FloorCell` instances
- Create more robust cell-manipulation methods on `Map3D` class
- Simplify `Cell3D` methods to rely more on `Map3D` methods
- Definitely assign `map` property in `Cell3D` class
- Create Actor archetype which includes actor-related utility methods (creating entities, hopping)
- Rename `getHopTarget` to `getValidHop` and improve logic for clearer code
- Move `DIRECTIONS` constant to static member of `Map3D` class (delete `constants.ts`)